### PR TITLE
Display log time

### DIFF
--- a/django_rich_logging/logging.py
+++ b/django_rich_logging/logging.py
@@ -21,6 +21,12 @@ class DjangoRequestHandler(logging.StreamHandler):
     def __init__(self, *args, **kwargs):
         super().__init__()
 
+        formatter = logging.Formatter(datefmt="%H:%M:%S")
+        if "formatter" in kwargs:
+            formatter = kwargs["formatter"]
+
+        self.formatter = formatter
+
         if "console" in kwargs:
             self.console = kwargs["console"]
 
@@ -33,6 +39,7 @@ class DjangoRequestHandler(logging.StreamHandler):
             self.uri_table.add_column("URI")
             self.uri_table.add_column("Status")
             self.uri_table.add_column("Size")
+            self.uri_table.add_column("Time")
 
             self.live = Live(self.uri_table, auto_refresh=False)
 
@@ -47,6 +54,7 @@ class DjangoRequestHandler(logging.StreamHandler):
             request = record.args[0]
             status = record.args[1]
             size = ""
+            time = self.formatter.formatTime(record, datefmt=self.formatter.datefmt)
 
             # Example: GET /profile HTTP/1.1
             matches = re.match(
@@ -78,6 +86,7 @@ class DjangoRequestHandler(logging.StreamHandler):
                         Text(uri, style="white bold"),
                         Text(status, style=style),
                         Text(size),
+                        Text(time),
                     )
                     self.live.start()
                     self.live.refresh()

--- a/tests/logging/django_request_handler/test_init.py
+++ b/tests/logging/django_request_handler/test_init.py
@@ -1,3 +1,5 @@
+import logging
+
 from django_rich_logging.logging import DjangoRequestHandler
 from rich.console import Console
 
@@ -13,6 +15,19 @@ def test_init_with_no_console():
     handler = DjangoRequestHandler()
 
     assert handler.console is not None
+
+
+def test_init_with_formatter():
+    formatter = logging.Formatter(datefmt="%Y-%m-%d %H:%M:%S")
+    handler = DjangoRequestHandler(formatter=formatter)
+
+    assert id(formatter) == id(handler.formatter)
+
+
+def test_init_with_no_formatter():
+    handler = DjangoRequestHandler()
+
+    assert handler.formatter is not None
 
 
 def test_init_with_live():


### PR DESCRIPTION
## Summary
This PR adds an extra column to the `rich` Console output for displaying the time.

<p align="center">
<img src="https://user-images.githubusercontent.com/6550256/179649988-50b25236-992b-43df-b202-edfeb22e8461.png" width="400">
</p>

## Changes
💡 In order to display a time, the logging handler needs a formatter that specifies a `datefmt`. This is needed so that the formatter can call [`formatTime`](https://docs.python.org/3/library/logging.html#logging.Formatter.formatTime), and we use that value to display!

- Have `DjangoRequestHandler.__init__` set a default formatter if none is passed in, else use passed in formatter
- Have `DjangoRequestHandler.emit` call `formatTime` on its formatter and adds extra column to log output
- Adds `DjangoRequestHandler.__init__` tests 🧪

## Testing
1. **Default formatter**: Run the example project to see the default formatter at work! Time format will be `HH:MM:SS`
2. **Custom formatter**: Add one of the pre-defined formatter to the [`django_rich_logging` handler here](https://github.com/adamghill/django-rich-logging/blob/1f97673069e5001c54cb76fdf8b73b22e290ed05/example/project/settings.py#L156-L159). Time format will be whatever the formatter's `datefmt` setting is.
   - For example if you add `"formatter": "verbose",`, the time format will be `YYYY-MM-DD HH:MM:SS` 

## Notes, Questions, & Follow-up
- Modify README to include note about **optionally** passing a formatter to the `django_rich_logging` handler
- Should the tests check for the cell content?
   - current tests does minimal checking for the `Method` and text color
   - time checking would require something like `freezegun`?
- Update gif?